### PR TITLE
Change textlib to core_text

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -342,7 +342,7 @@ class auth_plugin_casattras extends auth_plugin_base {
      */
     public function user_login ($username, $password) {
         $this->init_cas();
-        return phpCAS::isAuthenticated() && (trim(textlib::strtolower(phpCAS::getUser())) == $username);
+        return phpCAS::isAuthenticated() && (trim(core_text::strtolower(phpCAS::getUser())) == $username);
     }
 
     /**
@@ -355,7 +355,7 @@ class auth_plugin_casattras extends auth_plugin_base {
      * @return mixed array with no magic quotes or false on error
      */
     public function get_userinfo($username) {
-        if (!phpCAS::isAuthenticated() || trim(textlib::strtolower(phpCAS::getUser())) != $username) {
+        if (!phpCAS::isAuthenticated() || trim(core_text::strtolower(phpCAS::getUser())) != $username) {
             return array();
         }
 


### PR DESCRIPTION
It seems moodle deprecated textlib in version 2.6 and renamed it to core_text. After updating to 2.8, we were receiving warnings in the error logs about this. I updated auth.php to use the core_text library instead of textlib.