### PR TITLE
Switch to phpCAS::logout() without URL

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -380,9 +380,13 @@ class auth_plugin_casattras extends auth_plugin_base {
         global $CFG;
 
         if (!empty($this->config->logoutcas)) {
-            $backurl = $CFG->wwwroot;
+            //$backurl = $CFG->wwwroot;
             $this->init_cas();
-            phpCAS::logoutWithURL($backurl);
+            //phpCAS::logoutWithURL($backurl);
+
+            // logout($url) parameter is removed as of CAS 3.3.5.1, switching to logout()
+            // TODO: call phpCAS::logoutWithURL($backurl) or phpCAS::logout() based on CAS server version
+            phpCAS::logout();
         }
     }
 }


### PR DESCRIPTION
URL parameter is removed after CAS server version 3.3.5.1 so we were getting the following warning: 
PHP Deprecated:  Function deprecated for cas servers >= 3.3.5.1 in /var/www/moodle/auth/casattras/phpCAS/source/CAS.php on line 1506, referer:

Not sure how this would affect CAS < 3.3.5.1 logouts.
